### PR TITLE
SlackArchiveについて、Webサイトトップにも載せる

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,3 +29,7 @@ footer .copyright {
 .notice-ga {
   margin-top: 1em;
 }
+
+.text-center .caption {
+  text-align: left;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -33,3 +33,11 @@ footer .copyright {
 .text-center .caption {
   text-align: left;
 }
+
+
+/* 数値は https://v4-alpha.getbootstrap.com/layout/overview/#responsive-breakpoints を参考に、タブレットの幅に合わせた */
+@media (min-width: 768px) {
+  .hero-feature .thumbnail {
+    height: 33em;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                     <div class="caption">
                         <p>Haskell-jpが運営するblogです。記事の寄稿を常時募集しております。<br/>
                             <a href="https://github.com/haskell-jp/blog">こちらのリポジトリー</a>にPull Requestを送ってください！</p>
-                        <p>
+                        <p class="text-center">
                             <a href="/blog/" class="btn btn-primary">読んでみる</a>
                         </p>
                     </div>
@@ -104,8 +104,10 @@
                     </a>
                     <div class="caption">
                         <p>Haskellを使ってる人、Haskellを使ってみたい人、Haskellにちょっと興味がある人、だれでも参加できるSlackチームです。<br/>
-                          <strong>#general</strong> チャンネルでのHaskellに関する質問も歓迎します！</p>
-                        <p>
+                          <strong>#general</strong> チャンネルでのHaskellに関する質問も歓迎します！<br/>
+                          どんなやりとりがされているか試しに見てみたい、という場合、<a href="https://haskell-jp.slackarchive.io/">こちらのSlackArchive</a>から閲覧できます。
+                        </p>
+                        <p class="text-center">
                             <a href="https://join-haskell-jp-slack.herokuapp.com/" class="btn btn-primary">登録してみる</a>
                         </p>
                     </div>
@@ -120,7 +122,7 @@
                     </a>
                     <div class="caption">
                         <p>Haskellにありそうでなかった（はずの）レシピ集（逆引きテクニック辞典）です。調べて試してみましょう！</p>
-                        <p>
+                        <p class="text-center">
                             <a href="https://github.com/haskell-jp/recipe-collection" class="btn btn-primary">試してみる</a>
                         </p>
                     </div>
@@ -139,7 +141,7 @@
                     <div class="caption">
                         <!-- 相互リンクのバナーができ次第、相互リンクのリンク集に変える -->
                         <p>Haskell-jpの公式connpassグループにて、随時募集しています。ブログ記事やSlackで見かけるあの人にリアルで会えるかもしれません！</p>
-                        <p>
+                        <p class="text-center">
                             <a href="http://haskell-jp.connpass.com" class="btn btn-primary">参加してみる</a>
                         </p>
                     </div>
@@ -154,7 +156,7 @@
                     </a>
                     <div class="caption">
                         <p>Haskell-jpが管理するWikiです。GitHubアカウントでログインすると、どなたでも編集できます。</p>
-                        <p>
+                        <p class="text-center">
                             <a href="https://wiki.haskell.jp" class="btn btn-primary">読み書きしてみる</a>
                         </p>
                     </div>
@@ -171,7 +173,7 @@
                         <p>Haskell-jpの役目は、haskell.jpというドメインを通じてみなさんに場を提供することです。<br/>
                             <a href="https://join-haskell-jp-slack.herokuapp.com/">Slack</a>や<a href="https://github.com/haskell-jp">GitHubリポジトリーへのコントリビュート</a>などを通じて、Haskellを広めたい人、Haskellに関する情報を提供したい人の声をいつでもお待ちしております。
                         </p>
-                        <p>
+                        <p class="text-center">
                             <a href="https://join-haskell-jp-slack.herokuapp.com/" class="btn btn-primary">活動してみる</a>
                         </p>
                     </div>


### PR DESCRIPTION
ついでに、ボタンの説明がセンタリングされていたのを読みづらかったので修正。cssがちょっと汚くなってしまうが気にしない！

👇 こんな感じ。
![image](https://cloud.githubusercontent.com/assets/227057/26475841/241282f4-41f5-11e7-823a-cb6f4af50a83.png)
