### PR TITLE
Slack招待リンクの修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                         <a href="/blog/">Blog</a>
                     </li>
                     <li>
-                        <a href="https://join-haskell-jp-slack.herokuapp.com/">Slack Team</a>
+                        <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM">Slack Team</a>
                     </li>
                     <li>
                         <a href="https://www.reddit.com/r/haskell_jp/">Reddit</a>
@@ -90,8 +90,7 @@
                     </a>
                     <div class="caption">
                         <p>Haskellを使ってる人、Haskellを使ってみたい人、Haskellにちょっと興味がある人、だれでも参加できるSlackチームです。<br/>
-                          Haskellに関することなら何でも気軽に投稿できます。<br/>
-                          どんなやりとりがされているか試しに見てみたい、という場合、<a href="https://haskell-jp.slackarchive.io/">こちらのSlackArchive</a>から閲覧できます。
+                          Haskellに関することなら何でも気軽に投稿できます。
                         </p>
                         <p class="text-center">
                             <a href="https://join-haskell-jp-slack.herokuapp.com/" class="btn btn-primary">登録してみる</a>


### PR DESCRIPTION
# 概要
Slack招待用のリンクを新しいものに差し替えました。