### PR TITLE
Slack招待URLの再修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             </div>
             <div class="col-md-4 col-sm-6 hero-feature">
                 <div class="thumbnail">
-                    <a href="https://join-haskell-jp-slack.herokuapp.com/">
+                    <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM">
                         <h2>Contact (via Slack)</h2>
                         <img src="img/slack-frog.svg" alt="Slackで突っ込みを入れる蛙" style="margin-left: 30%; margin-right: 30%;">
                     </a>
@@ -93,7 +93,7 @@
                           Haskellに関することなら何でも気軽に投稿できます。
                         </p>
                         <p class="text-center">
-                            <a href="https://join-haskell-jp-slack.herokuapp.com/" class="btn btn-primary">登録してみる</a>
+                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM" class="btn btn-primary">登録してみる</a>
                         </p>
                     </div>
                 </div>
@@ -175,16 +175,16 @@
             </div>
             <div class="col-md-4 col-sm-6 hero-feature">
                 <div class="thumbnail">
-                    <a href="https://join-haskell-jp-slack.herokuapp.com/">
+                    <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM">
                         <h2>And More!</h2>
                         <img src="img/now-frog.svg" alt="煽る蛙" style="margin-left: 30%; margin-right: 30%;">
                     </a>
                     <div class="caption">
                         <p>Haskell-jpの役目は、haskell.jpというドメインを通じてみなさんに場を提供することです。<br/>
-                            <a href="https://join-haskell-jp-slack.herokuapp.com/">Slack</a>や<a href="https://github.com/haskell-jp">GitHubリポジトリーへのコントリビュート</a>などを通じて、Haskellを広めたい人、Haskellに関する情報を提供したい人の声をいつでもお待ちしております。
+                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM">Slack</a>や<a href="https://github.com/haskell-jp">GitHubリポジトリーへのコントリビュート</a>などを通じて、Haskellを広めたい人、Haskellに関する情報を提供したい人の声をいつでもお待ちしております。
                         </p>
                         <p class="text-center">
-                            <a href="https://join-haskell-jp-slack.herokuapp.com/" class="btn btn-primary">活動してみる</a>
+                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLTAzZGNkZDlkMWYxZDRlODI3NmNlNTQ1ZDc3MjQxNzg3OTg4YzUzNmUyNmU5YWVkMjFmMjFjYzk1OTE3Yzg4ZTM" class="btn btn-primary">活動してみる</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
# 概要
Slack招待用URLで、まだ修正できていなかった部分を修正しました。