### PR TITLE
Slackの招待リンクへ転送するためだけのページを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                         <a href="/blog/">Blog</a>
                     </li>
                     <li>
-                        <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">Slack Team</a>
+                        <a href="./signin-slack.html">Slack Team</a>
                     </li>
                     <li>
                         <a href="https://www.reddit.com/r/haskell_jp/">Reddit</a>
@@ -84,7 +84,7 @@
             </div>
             <div class="col-md-4 col-sm-6 hero-feature">
                 <div class="thumbnail">
-                    <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">
+                    <a href="./signin-slack.html">
                         <h2>Contact (via Slack)</h2>
                         <img src="img/slack-frog.svg" alt="Slackで突っ込みを入れる蛙" style="margin-left: 30%; margin-right: 30%;">
                     </a>
@@ -93,7 +93,7 @@
                           Haskellに関することなら何でも気軽に投稿できます。
                         </p>
                         <p class="text-center">
-                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc" class="btn btn-primary">登録してみる</a>
+                            <a href="./signin-slack.html" class="btn btn-primary">登録してみる</a>
                         </p>
                     </div>
                 </div>
@@ -190,16 +190,16 @@
             </div>
             <div class="col-md-4 col-sm-6 hero-feature">
                 <div class="thumbnail">
-                    <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">
+                    <a href="./signin-slack.html">
                         <h2>And More!</h2>
                         <img src="img/now-frog.svg" alt="煽る蛙" style="margin-left: 30%; margin-right: 30%;">
                     </a>
                     <div class="caption">
                         <p>Haskell-jpの役目は、haskell.jpというドメインを通じてみなさんに場を提供することです。<br/>
-                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">Slack</a>や<a href="https://github.com/haskell-jp">GitHubリポジトリーへのコントリビュート</a>などを通じて、Haskellを広めたい人、Haskellに関する情報を提供したい人の声をいつでもお待ちしております。
+                            <a href="./signin-slack.html">Slack</a>や<a href="https://github.com/haskell-jp">GitHubリポジトリーへのコントリビュート</a>などを通じて、Haskellを広めたい人、Haskellに関する情報を提供したい人の声をいつでもお待ちしております。
                         </p>
                         <p class="text-center">
-                            <a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc" class="btn btn-primary">活動してみる</a>
+                            <a href="./signin-slack.html" class="btn btn-primary">活動してみる</a>
                         </p>
                     </div>
                 </div>

--- a/signin-slack.html
+++ b/signin-slack.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>Slack 登録ページに転送しています...</title>
+    <meta http-equiv="Refresh" content="0; url=https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc" />
+  </head>
+  <body>
+  Slack 登録ページに転送しています...<br />
+  移動しない場合は<a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">こちら</a>をクリックしてください。
+  </body>
+</html>


### PR DESCRIPTION
https://github.com/haskell-jp/community/issues/6 と https://github.com/haskell-jp/community/issues/16 でのトラブルを受けて、Slackの招待リンクをより簡単に更新できるよう、リダイレクトするだけのページを作り、取り急ぎ index.html において従来のSlackの招待リンクを参照している箇所を修正した。

今後は、signin-slack.htmlにある二カ所のURLを更新するだけでSlackの招待リンクを更新できるようになる。