### PR TITLE
Haskell Day 2021 タイムテーブルの見ため

### DIFF
--- a/haskell-day-2021/index.html
+++ b/haskell-day-2021/index.html
@@ -4,6 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="/haskell-day-2021/style.css?202106061226" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <title>Haskell Day 2021 #HaskellDay</title>
     <meta property="og:title" content="Haskell Day 2021" />
     <meta property="og:type" content="website" />
@@ -46,20 +47,20 @@
 
       </article>
       <article id="presentation">
-        <h1>発表・タイムスケジュール</h1>
-        <table class="tableizer-table">
-          <thead><tr class="tableizer-firstrow"><th>Time</th><th>Title</th><th>Speaker</th></tr></thead><tbody>
-            <tr><td>13:00~13:10</td><td class="title">Haskell Dayの紹介</td><td></td></tr>
-            <tr><td>13:10~13:55</td><td class="title">招待講演</td><td>&#x2728;豪華ゲスト</td></tr>
-            <tr><td>14:00~14:15</td><td class="title" onClick="openModal('GHCの動向2021', 'mod_poppo', 'Haskellの処理系であるGHCは現在も活発に開発が行われています。この発表ではGHCの最近の開発状況や、直近あるいは将来リリースされるGHC 9.xでの新機能・変更点を簡単に紹介します。')"><span class="action">GHCの動向2021</span></td><td>mod_poppo</td></tr>
-            <tr><td>14:20~14:50</td><td class="title" onClick="openModal('Haskellは別言語になりました――RecordDotSyntaxとNoFieldSelectors', 'fumieval', 'Haskellは、レコード(構造体)を定義すると、各フィールドにアクセスするための関数が定義されます。しかし、フィールド名が衝突したり、それを避けるために名前が冗長になったりするため、レコードが使いにくいという評価を受けることも。GHC 9.2では、その問題の解決策としてNoFieldSelectorsとRecordDotSyntaxという二つの言語拡張が導入されました。それらの動機、仕組み、使い方について解説します。')"><span class="action">Haskellは別言語になりました――RecordDotSyntaxとNoFieldSelectors</span></td><td>fumieval</td></tr>
-            <tr><td>14:55~15:10</td><td class="title" onClick="openModal('Asterius による WebAssembly 開発（仮）', 'チェシャ猫', 'Asterius を用いて Haskell のソースコードを WebAssembly にコンパイルして実行する流れを解説します。動きのあるデモを発表の主体とし、中間言語やコンパイラの実装などには触れない予定です。WebAssembly 自体に関する予備知識も仮定しません。Haskell 自体の文法に関する予備知識は仮定します。')"><span class="action">Asterius による WebAssembly 開発（仮）</span></td><td>チェシャ猫</td></tr>
-            <tr><td>15:15~15:45</td><td class="title" onClick="openModal('GraphQLとHaskell', '中嶋大嗣', 'GraphQLの入門\nHaskellによるGraphQL APIの実装を目的に、関連ライブラリの紹介及び、サンプルを交えて実装の紹介を行います')"><span class="action">GraphQLとHaskell</span></td><td>中嶋大嗣</td></tr>
-            <tr><td>15:50~16:20</td><td class="title" onClick="openModal('`take k (sort xs)` in Haskell has O(n + k log k) time complexity', 'Kazuhiko Sakaguchi', '本発表では、長さ n のリスト xs の最小（もしくは最大）の k 要素を take k (sort xs) を必要呼びで評価することで求めるのにかかる時間計算量が O(n + k log k) であることを証明する。\nIn this talk, we prove that computing the first `k` smallest (or largest) elements of a list `xs` of length `n` by `take k (sort xs)` in the call-by-need evaluation strategy has O(n + k log k) time complexity, which is the optimal time-bound of the incremental sorting problem [Paredes and Navarro 2006].')"><span class="action">`take k (sort xs)` in Haskell has O(n + k log k) time complexity</span></td><td>Kazuhiko Sakaguchi</td></tr>
-            <tr><td>16:25~16:55</td><td class="title" onClick="openModal('線形型の刹那的不変データ構造への利用', '岡本和樹', 'GHC 9.0 で線形型が導入されました\n線形型は「値が一度しか使われない」ことを保証するものです\nこれを使用して計算量の関係から1回しか値の使えない「刹那的データ構造」を型安全にする方法を説明します')"><span class="action">線形型の刹那的不変データ構造への利用</span></td><td>岡本和樹</td></tr>
-            <tr><td>17:00~17:15</td><td class="title" onClick="openModal('slack-logの紹介', '山本悠滋', 'Slackの発言を保存するバッチアプリケーション、slack-log https://github.com/haskell-jp/slack-log/ について開発の動機や実装、設計、使用するライブラリーの紹介、今後加えたい修正についてお話しします。')"><span class="action">slack-logの紹介</span></td><td>山本悠滋</td></tr>
-            <tr><td>17:20~17:50</td><td class="title" onClick="openModal('GHCによるHaskellプログラムの動かし方', 'Mizunashi Mana', 'Haskell は他の言語にない意味論的特徴を多く持っています．そのため，Haskell の標準的実装 GHC でも，Haskell プログラムを動かす上で，他の言語では見られないような様々な工夫が施されています．この工夫を知ることは，Haskell プログラムへの理解を深める上でも，プログラムの動作を調査する上でも役に立つでしょう．この発表では，GHC が Haskell プログラムをどのように動かすのかについて，基本的な概要を紹介します．')"><span class="action">GHCによるHaskellプログラムの動かし方</span></td><td>Mizunashi Mana</td></tr>
-            <tr><td>17:50~17:55</td><td class="title">クロージング</td><td></td></tr>
+        <h1>発表・タイムテーブル</h1>
+        <table>
+          <thead><tr><th class='time'>時刻</th><th class='title'>タイトル</th><th>スピーカー</th></tr></thead><tbody>
+            <tr><td>13:00～13:10</td><td class="title">Haskell Day の紹介</td><td></td></tr>
+            <tr><td>13:10～13:55</td><td class="title">招待講演</td><td>&#x2728;豪華ゲスト</td></tr>
+            <tr><td>14:00～14:15</td><td class="title"><span class="action" onClick="openModal(mod_poppo)">GHC の動向 2021</span></td><td>mod_poppo</td></tr>
+            <tr><td>14:20～14:50</td><td class="title"><span class="action" onClick="openModal(fumieval)">Haskell は別言語になりました――RecordDotSyntax と NoFieldSelectors</span></td><td>fumieval</td></tr>
+            <tr><td>14:55～15:10</td><td class="title"><span class="action" onClick="openModal(チェシャ猫)">Asterius による WebAssembly 開発（仮）</span></td><td>チェシャ猫</td></tr>
+            <tr><td>15:15～15:45</td><td class="title"><span class="action" onClick="openModal(中嶋大嗣)">GraphQL と Haskell</span></td><td>中嶋大嗣</td></tr>
+            <tr><td>15:50～16:20</td><td class="title"><span class="action" onClick="openModal(sakaguchi)"><code>take k (sort xs)</code> in Haskell has O(n + k log k) time complexity</span></td><td>Kazuhiko Sakaguchi</td></tr>
+            <tr><td>16:25～16:55</td><td class="title"><span class="action" onClick="openModal(岡本和樹)">線形型の刹那的不変データ構造への利用</span></td><td>岡本和樹</td></tr>
+            <tr><td>17:00～17:15</td><td class="title"><span class="action" onClick="openModal(山本悠滋)">slack-log の紹介</span></td><td>山本悠滋</td></tr>
+            <tr><td>17:20～17:50</td><td class="title"><span class="action" onClick="openModal(mizunashi)">GHC による Haskell プログラムの動かし方</span></td><td>Mizunashi Mana</td></tr>
+            <tr><td>17:50～17:55</td><td class="title">クロージング</td><td></td></tr>
         </tbody></table>
         <p>日程の詳細は<a href="#schedule">スケジュール</a>をご覧ください。</p>
       </article>
@@ -146,37 +147,15 @@
       <p id="hosted"><a href="https://haskell.jp/"><img src="/haskell-day-2021/haskell-jp.svg" id="haskell-jp-logo" /></a></p>
     </footer>
 
-    <div id="modal" class="modal">
-      <div class="modalContent">
-        <span id="modalClose" class="close">&times;</span>
-        <h3 id="modalTitle"></h3>
-        <p id="modalSpeaker"></p>
+    <div id="modal" class="modal" onclick="closeModal()">
+      <div class="modal-content">
+        <span class="material-icons modal-close" onclick="closeModal()">close</span>
+        <h3 id="modal-title"></h3>
+        <p id="modal-speaker"></p>
         <hr/>
-        <p id="modalDescription"></p>
+        <p id="modal-description"></p>
       </div>
     </div>
-
-    <script>
-      var modal = document.getElementById('modal');
-      var openModal = function (title, speaker, description) {
-        modal.style.display = 'block';
-        var set = function (id, c) {
-          document.getElementById(id).textContent = c;
-        }
-        set('modalTitle', title)
-        set('modalSpeaker', speaker);
-        set('modalDescription', description);
-      };
-      var close = function() {
-        modal.style.display = 'none';
-      };
-      document.getElementById('modalClose').onclick = close;
-      window.onclick = function(event) {
-        if (event.target == modal) {
-          close();
-        }
-      }
-    </script>
-
+    <script src="/haskell-day-2021/script.js"></script>
   </body>
 </html>

--- a/haskell-day-2021/script.js
+++ b/haskell-day-2021/script.js
@@ -1,0 +1,53 @@
+const mod_poppo = {
+  title: 'GHC の動向 2021',
+  speaker: 'mod_poppo',
+  description: 'Haskell の処理系である GHC は現在も活発に開発が行われています。この発表では GHC の最近の開発状況や、直近あるいは将来リリースされる GHC 9.x での新機能・変更点を簡単に紹介します。'
+};
+const fumieval = {
+  title: 'Haskell は別言語になりました――RecordDotSyntax と NoFieldSelectors',
+  speaker: 'fumieval',
+  description: 'Haskell は、レコード（構造体）を定義すると、各フィールドにアクセスするための関数が定義されます。しかし、フィールド名が衝突したり、それを避けるために名前が冗長になったりするため、レコードが使いにくいという評価を受けることも。GHC 9.2 では、その問題の解決策として NoFieldSelectors と RecordDotSyntax という二つの言語拡張が導入されました。それらの動機、仕組み、使い方について解説します。'
+};
+const チェシャ猫 = {
+  title: 'Asterius による WebAssembly 開発（仮）',
+  speaker: 'チェシャ猫',
+  description: 'Asterius を用いて Haskell のソースコードを WebAssembly にコンパイルして実行する流れを解説します。動きのあるデモを発表の主体とし、中間言語やコンパイラの実装などには触れない予定です。WebAssembly 自体に関する予備知識も仮定しません。Haskell 自体の文法に関する予備知識は仮定します。'
+};
+const 中嶋大嗣 = {
+  title: 'GraphQL と Haskell',
+  speaker: '中嶋大嗣',
+  description: 'GraphQL の入門<br>Haskell による GraphQL API の実装を目的に、関連ライブラリの紹介及び、サンプルを交えて実装の紹介を行います'
+};
+const sakaguchi = {
+  title: '<code>take k (sort xs)</code> in Haskell has O(n + k log k) time complexity',
+  speaker: 'Kazuhiko Sakaguchi',
+  description: '本発表では、長さ n のリスト xs の最小（もしくは最大）の k 要素を take k (sort xs) を必要呼びで評価することで求めるのにかかる時間計算量が O(n + k log k) であることを証明する。<br>In this talk, we prove that computing the first <code>k</code> smallest (or largest) elements of a list <code>xs</code> of length <code>n</code> by <code>take k (sort xs)</code> in the call-by-need evaluation strategy has O(n + k log k) time complexity, which is the optimal time-bound of the incremental sorting problem [Paredes and Navarro 2006].'
+};
+const 岡本和樹 = {
+  title: '線形型の刹那的不変データ構造への利用',
+  speaker: '岡本和樹',
+  description: 'GHC 9.0 で線形型が導入されました<br>線形型は「値が一度しか使われない」ことを保証するものです<br>これを使用して計算量の関係から1回しか値の使えない「刹那的データ構造」を型安全にする方法を説明します'
+};
+const 山本悠滋 = {
+  title: 'slack-log の紹介',
+  speaker: '山本悠滋',
+  description: 'Slack の発言を保存するバッチアプリケーション、<a href="https://github.com/haskell-jp/slack-log/">slack-log</a> について開発の動機や実装、設計、使用するライブラリーの紹介、今後加えたい修正についてお話しします。'
+};
+const mizunashi = {
+  title: 'GHC による Haskell プログラムの動かし方',
+  speaker: 'Mizunashi Mana',
+  description: 'Haskell は他の言語にない意味論的特徴を多く持っています．そのため，Haskell の標準的実装 GHC でも，Haskell プログラムを動かす上で，他の言語では見られないような様々な工夫が施されています．この工夫を知ることは，Haskell プログラムへの理解を深める上でも，プログラムの動作を調査する上でも役に立つでしょう．この発表では，GHC が Haskell プログラムをどのように動かすのかについて，基本的な概要を紹介します．'
+};
+
+const modal = document.getElementById('modal');
+
+const openModal = function (data) {
+  modal.style.display = 'block';
+  document.getElementById('modal-title').innerHTML = data.title;
+  document.getElementById('modal-speaker').textContent = data.speaker;
+  document.getElementById('modal-description').innerHTML = data.description;
+};
+
+const closeModal = function() {
+  modal.style.display = 'none';
+};

--- a/haskell-day-2021/style.css
+++ b/haskell-day-2021/style.css
@@ -225,7 +225,8 @@ span.action {
   max-width: 540px;
   position: relative;
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
   border-radius: 5px;
   box-shadow: 0px 4px 8px 4px rgba(0, 0, 0, 0.3);
 }

--- a/haskell-day-2021/style.css
+++ b/haskell-day-2021/style.css
@@ -185,22 +185,25 @@ footer > article > ul > li {
   padding: 10px;
 }
 
-table.tableizer-table {
-    margin-top: 20px;
-    max-width: 600px;
-    border-collapse:  collapse;
+#presentation > table {
+  margin-top: 20px;
+  max-width: 616px;
+  border-collapse: collapse;
 }
-table.tableizer-table th,td {
-    border: solid 1px;
-    padding: 10px 5px;
+#presentation > table th,
+#presentation > table td {
+  border: solid 1px rgba(0, 0, 0, 0.3);
+  padding: 10px 5px;
 }
-table.tableizer-table td {
-    /* word-break: normal; */
-    /* overflow-wrap: break-word; */
+#presentation > table .time {
+  width: 20%;
+}
+#presentation > table .title {
+  width: 60%;
 }
 span.action {
-    cursor: pointer;
-    color: #0033cc;
+  cursor: pointer;
+  color: #0033cc;
 }
 
 /* modal */
@@ -212,24 +215,28 @@ span.action {
   top: 0;
   width: 100%;
   height: 100%;
-  padding-top: 10%;
   background-color: rgba(0,0,0,0.3);
 }
-.modalContent {
+.modal-content {
   background-color: #fff;
   margin: auto;
-  padding: 0 20px 10px 20px;
-  width: 80%;
-  white-space: pre-line;
+  padding: 20px;
+  margin: 12px;
+  max-width: 540px;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  border-radius: 5px;
+  box-shadow: 0px 4px 8px 4px rgba(0, 0, 0, 0.3);
 }
-.close {
+.modal-close {
   color: #888;
   float: right;
   font-size: 28px;
   font-weight: bold;
 }
-.close:hover,
-.close:focus {
+.modal-close:hover,
+.modal-close:focus {
   color: #000;
   cursor: pointer;
 }


### PR DESCRIPTION
JS の挙動などはほぼ変わってないはず

「スケジュール」と「タイムスケジュール」が混同しそうだったので「タイムスケジュール」は「タイムテーブル」にしました