### PR TITLE
Haskell Day 2021 レイアウトの修正

### DIFF
--- a/haskell-day-2021/index.html
+++ b/haskell-day-2021/index.html
@@ -148,12 +148,14 @@
     </footer>
 
     <div id="modal" class="modal" onclick="closeModal()">
-      <div class="modal-content">
-        <span class="material-icons modal-close" onclick="closeModal()">close</span>
-        <h3 id="modal-title"></h3>
-        <p id="modal-speaker"></p>
-        <hr/>
-        <p id="modal-description"></p>
+      <div class="modal-container">
+        <div class="modal-content">
+          <span class="material-icons modal-close" onclick="closeModal()">close</span>
+          <h3 id="modal-title"></h3>
+          <p id="modal-speaker"></p>
+          <hr/>
+          <p id="modal-description"></p>
+        </div>
       </div>
     </div>
     <script src="/haskell-day-2021/script.js"></script>

--- a/haskell-day-2021/style.css
+++ b/haskell-day-2021/style.css
@@ -217,16 +217,17 @@ span.action {
   height: 100%;
   background-color: rgba(0,0,0,0.3);
 }
-.modal-content {
-  background-color: #fff;
+.modal-container {
   margin: auto;
-  padding: 20px;
-  margin: 12px;
-  max-width: 540px;
+  max-width: 564px;
   position: relative;
   top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateY(-50%);
+}
+.modal-content {
+  background-color: #fff;
+  margin: 12px;
+  padding: 20px;
   border-radius: 5px;
   box-shadow: 0px 4px 8px 4px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
細い画面で見たときのレイアウトがくずれていた

<details>

現状
![Screenshot_20210731-021123](https://user-images.githubusercontent.com/282593/127688625-6a7648a4-eab1-4ea8-aedc-99d935d3328b.png)

修正
![Screenshot_20210731-021133](https://user-images.githubusercontent.com/282593/127688659-504a4e81-74dd-4d5e-aa71-aed82a2ee34c.png)

</details>