### PR TITLE
modal や modal-close 以外をクリックしてもモーダルウィンドーが閉じないように

### DIFF
--- a/haskell-day-2021/index.html
+++ b/haskell-day-2021/index.html
@@ -148,7 +148,7 @@
     </footer>
 
     <div id="modal" class="modal" onclick="closeModal()">
-      <div class="modal-content">
+      <div id="modal-content" class="modal-content">
         <span class="material-icons modal-close" onclick="closeModal()">close</span>
         <h3 id="modal-title"></h3>
         <p id="modal-speaker"></p>

--- a/haskell-day-2021/script.js
+++ b/haskell-day-2021/script.js
@@ -40,8 +40,9 @@ const mizunashi = {
 };
 
 const modal = document.getElementById('modal');
+const modalContent = document.getElementById('modal-content');
 
-const openModal = function (data) {
+const openModal = function(data) {
   modal.style.display = 'block';
   document.getElementById('modal-title').innerHTML = data.title;
   document.getElementById('modal-speaker').textContent = data.speaker;
@@ -51,3 +52,5 @@ const openModal = function (data) {
 const closeModal = function() {
   modal.style.display = 'none';
 };
+
+modalContent.onclick = (event) => { event.stopPropagation(); };


### PR DESCRIPTION
問題：発表の概要などをコピーしようとクリックするとモーダルウィンドーが閉じてしまう。