### PR TITLE
山本悠滋の発表時間は実際には20分弱程度欲しいので、5分後ろ倒しにする

### DIFF
--- a/haskell-day-2021/index.html
+++ b/haskell-day-2021/index.html
@@ -57,9 +57,9 @@
             <tr><td>14:00～14:23</td><td class="title"><a id="timetable-中嶋大嗣" class="action" tabindex="0">GraphQL と Haskell</a></td><td>中嶋大嗣</td></tr>
             <tr><td>14:30～14:50</td><td class="title"><a id="timetable-sakaguchi" class="action" tabindex="0"><code>take k (sort xs)</code> in Haskell has O(n + k log k) time complexity</a></td><td>Kazuhiko Sakaguchi</td></tr>
             <tr><td>14:55～15:26</td><td class="title"><a id="timetable-岡本和樹" class="action" tabindex="0">線形型の刹那的不変データ構造への利用</a></td><td>岡本和樹</td></tr>
-            <tr><td>15:30～15:45</td><td class="title"><a id="timetable-山本悠滋" class="action" tabindex="0">slack-log の紹介</a></td><td>山本悠滋</td></tr>
-            <tr><td>15:50～16:15</td><td class="title"><a id="timetable-mizunashi" class="action" tabindex="0">GHC による Haskell プログラムの動かし方</a></td><td>Mizunashi Mana</td></tr>
-            <tr><td>16:15～16:20</td><td class="title">クロージング</td><td></td></tr>
+            <tr><td>15:30～15:50</td><td class="title"><a id="timetable-山本悠滋" class="action" tabindex="0">slack-log の紹介</a></td><td>山本悠滋</td></tr>
+            <tr><td>15:55～16:20</td><td class="title"><a id="timetable-mizunashi" class="action" tabindex="0">GHC による Haskell プログラムの動かし方</a></td><td>Mizunashi Mana</td></tr>
+            <tr><td>16:20～16:25</td><td class="title">クロージング</td><td></td></tr>
         </tbody></table>
         <p>日程の詳細は<a href="#schedule">スケジュール</a>をご覧ください。</p>
       </article>


### PR DESCRIPTION
「元々の時間だとハイペースすぎるので再生速度を0.8倍くらいにしたい」という要件を新しいタイムテーブルに反映し忘れてしまった

Ref. https://github.com/haskell-jp/community/issues/69