### PR TITLE
Slack Workspaceに登録する前に、メッセージの保存について周知するよう修正

### DIFF
--- a/signin-slack.html
+++ b/signin-slack.html
@@ -16,7 +16,7 @@ h1 {
 }
 h1 > img {
   width: 6.5em;
-  vertical-align: -0.45em;;
+  vertical-align: -0.45em;
   padding-right: 0.3em;
 }
 a { color: #337ab7; }
@@ -29,7 +29,7 @@ a:hover { color: #d66c79; }
 }
 </style>
 <body>
-<div style="background-color: #FFF; padding: 1em; margin-left: 1em; margin-right: 1em; max-width: 1000px;">
+<div style="background-color: #FFF; padding: 1em; margin: 1em; max-width: 1000px;">
   <h1><img src="img/logo.svg">Slack Workspaceにようこそ！</h1>
   <p>
     当Slack Workspaceでは、<a href="https://github.com/haskell-jp/slack-log/">slack-log</a> というツールを使用して大半のチャンネルにおける<strong>メッセージを保存</strong>し、<a href="https://haskell.jp/slack-log/">haskell.jp/slack-log</a> にて<strong>公開</strong>しています。また、メッセージの内容に加えて、<a href="https://haskell.jp/slack-log/">haskell.jp/slack-log</a> における正常な表示のため、当Slack Workspaceにおけるすべてのユーザーのスクリーンネームも保存・公開しています。スクリーンネームは発言の有無に関わらず保存・公開の対象となるのでご注意ください。

--- a/signin-slack.html
+++ b/signin-slack.html
@@ -1,12 +1,48 @@
 <!DOCTYPE html>
 <html lang="ja">
-  <head>
-    <meta charset="utf-8">
-    <title>Slack 登録ページに転送しています...</title>
-    <meta http-equiv="Refresh" content="0; url=https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc" />
-  </head>
-  <body>
-  Slack 登録ページに転送しています...<br />
-  移動しない場合は<a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">こちら</a>をクリックしてください。
-  </body>
+<head>
+<meta charset="utf-8">
+<title>Haskell-jp Slack Workspaceにようこそ！</title>
+</head>
+<link rel="shortcut icon" href="img/favicon.png" type="image/png" />
+<style>
+body {
+  background-image: url('img/background.png');
+  background-color: #F3DFBC;
+}
+h1 {
+  text-align: center;
+  font-size: 1.5em;
+}
+h1 > img {
+  width: 6.5em;
+  vertical-align: -0.45em;;
+  padding-right: 0.3em;
+}
+a { color: #337ab7; }
+a:hover { color: #d66c79; }
+
+::selection {
+  color: white;
+  text-shadow: none;
+  background: #d66c79;
+}
+</style>
+<body>
+<div style="background-color: #FFF; padding: 1em; margin-left: 1em; margin-right: 1em; max-width: 1000px;">
+  <h1><img src="img/logo.svg">Slack Workspaceにようこそ！</h1>
+  <p>
+    当Slack Workspaceでは、<a href="https://github.com/haskell-jp/slack-log/">slack-log</a> というツールを使用して大半のチャンネルにおける<strong>メッセージを保存</strong>し、<a href="https://haskell.jp/slack-log/">haskell.jp/slack-log</a> にて<strong>公開</strong>しています。また、メッセージの内容に加えて、<a href="https://haskell.jp/slack-log/">haskell.jp/slack-log</a> における正常な表示のため、当Slack Workspaceにおけるすべてのユーザーのスクリーンネームも保存・公開しています。スクリーンネームは発言の有無に関わらず保存・公開の対象となるのでご注意ください。
+  </p>
+  <p>
+    なお、投稿したメッセージの削除を希望される場合は、当 Slack Workspace を運営している <a href="https://github.com/haskell-jp/community/blob/master/admins/staff.md">Haskell-jp Admins のメンバー</a>にご連絡ください。
+  </p>
+  <p>
+    ご利用の場合は、<strong>以上に同意の上</strong>で下記からご登録ください:
+  </p>
+  <p style="text-align: center;">
+    <strong><a href="https://join.slack.com/t/haskell-jp/shared_invite/enQtNDY4Njc1MTA5MDQxLWY1ZDVhZjIzMGE1MDMzZDAyNGZmYTU5M2VlODg5NTNmY2QwNGU1NjJjMjYzN2VjZmRjMDNiNGU0NjI5NDdlMTc">メッセージの保存に同意の上で登録する</a></strong>
+  </p>
+</div>
+</body>
 </html>


### PR DESCRIPTION
我らがSlack Workspaceにおいて、メッセージなどを保存・公開しているということが十分に周知できていない問題が発覚したため、現在招待リンクへの転送のみに使用しているsignin-slack.htmlを、同意をとるページとして書き換えました。
内容をHaskell-jp Adminsのメンバーに確認いただいた上でマージし、既存のユーザーのみなさんにも同様の内容をSlackのgeneralチャンネル・randomチャンネルで周知しようと思います。

スクリーンショット:

![image](https://user-images.githubusercontent.com/227057/155833516-982a94b7-95f6-405f-9efa-abc66b77e503.png)
